### PR TITLE
Change FluidContainer registration to fill empty vials => water vials

### DIFF
--- a/src/main/java/xreliquary/proxy/CommonProxy.java
+++ b/src/main/java/xreliquary/proxy/CommonProxy.java
@@ -34,7 +34,7 @@ public class CommonProxy {
 		XRBlocks.init();
 		Alkahestry.init();
 
-		FluidContainerRegistry.registerFluidContainer(new FluidStack(FluidRegistry.WATER, FluidContainerRegistry.BUCKET_VOLUME / 8), new ItemStack(XRItems.condensedPotion), XRItems.potion(Reference.WATER_META));
+		FluidContainerRegistry.registerFluidContainer(new FluidStack(FluidRegistry.WATER, FluidContainerRegistry.BUCKET_VOLUME / 8), new ItemStack(XRItems.potion(WATER_META)), XRItems.potion(Reference.EMPTY_VIAL_META));
 	}
 
 	public void init() {


### PR DESCRIPTION
Change the registration in the FluidContainer registry to allow 
Empty Vial + Water = Vial of Ordinary water
instead of the current
 Water Vial + Water = Condensed Splash Serum
which bipasses the recipe requiring netherwart, gunpowder and glowstone.
