### PR TITLE
Side-Only Types of Fixes and Minor Improvements

### DIFF
--- a/src/main/java/xreliquary/blocks/BlockApothecaryCauldron.java
+++ b/src/main/java/xreliquary/blocks/BlockApothecaryCauldron.java
@@ -156,14 +156,16 @@ public class BlockApothecaryCauldron extends BlockBase {
                     collidingEntity.attackEntityFrom(DamageSource.inFire, 1.0F);
                 }
             }
-        }
+        
 
-
-        if (collidingEntity instanceof EntityItem) {
-            ItemStack item = ((EntityItem) collidingEntity).getEntityItem();
-            if (cauldron.isItemValidForInput(item)) {
-                cauldron.addItem(item);
-                collidingEntity.setDead();
+            if (collidingEntity instanceof EntityItem) {
+                ItemStack item = ((EntityItem) collidingEntity).getEntityItem();
+                while (cauldron.isItemValidForInput(item)) {
+                    
+                    cauldron.addItem(item);
+                    if (--item.stackSize < 1)
+                        collidingEntity.setDead();
+                }
             }
         }
     }

--- a/src/main/java/xreliquary/blocks/tile/TileEntityCauldron.java
+++ b/src/main/java/xreliquary/blocks/tile/TileEntityCauldron.java
@@ -1,6 +1,8 @@
 package xreliquary.blocks.tile;
 
 import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import lib.enderwizards.sandstone.blocks.tile.TileEntityBase;
 import lib.enderwizards.sandstone.init.ContentHandler;
 import net.minecraft.block.Block;
@@ -46,17 +48,19 @@ public class TileEntityCauldron extends TileEntityBase {
                 if(cookTime < getCookTime())
                     cookTime++;
             }
-            for (int particleCount = 0; particleCount <= 2; ++particleCount)
-                spawnBoilingParticles();
-            if (hasGunpowder) spawnGunpowderParticles();
-            if (hasGlowstone) spawnGlowstoneParticles();
-            if (hasNetherwart) {
-                spawnNetherwartParticles();
-                if (potionEssence != null) {
-                    spawnFinishedParticles();
+            if (worldObj.isRemote) {
+                for (int particleCount = 0; particleCount <= 2; ++particleCount)
+                    spawnBoilingParticles();
+                if (hasGunpowder) spawnGunpowderParticles();
+                if (hasGlowstone) spawnGlowstoneParticles();
+                if (hasNetherwart) {
+                    spawnNetherwartParticles();
+                    if (potionEssence != null) {
+                        spawnFinishedParticles();
+                    }
                 }
+                if (redstoneCount > 0) spawnRedstoneParticles();
             }
-            if (redstoneCount > 0) spawnRedstoneParticles();
         }
     }
 
@@ -65,7 +69,7 @@ public class TileEntityCauldron extends TileEntityBase {
         return oldBlock != newBlock;
     }
 
-    public void spawnBoilingParticles() {
+    @SideOnly(Side.CLIENT)public void spawnBoilingParticles() {
         if (worldObj.rand.nextInt(getCookTime() * getCookTime()) > cookTime * cookTime)
             return;
         float xOffset = (worldObj.rand.nextFloat() - 0.5F) / 1.33F;
@@ -80,11 +84,9 @@ public class TileEntityCauldron extends TileEntityBase {
 
         EntityCauldronBubbleFX bubble = new EntityCauldronBubbleFX(worldObj, xCoord + 0.5D + xOffset, yCoord + 0.01D + BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), zCoord + 0.5D + zOffset, 0D, 0D, 0D, red, green, blue);
         EntityCauldronSteamFX steam = new EntityCauldronSteamFX(worldObj, xCoord + 0.5D + xOffset, yCoord + 0.01D + BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), zCoord + 0.5D + zOffset, 0D, 0.05D + 0.02F * BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), 0D, red, green, blue);
-        if (worldObj.isRemote) {
-            FMLClientHandler.instance().getClient().effectRenderer.addEffect(bubble);
-            if (worldObj.rand.nextInt(6) == 0)
-                FMLClientHandler.instance().getClient().effectRenderer.addEffect(steam);
-        }
+        FMLClientHandler.instance().getClient().effectRenderer.addEffect(bubble);
+        if (worldObj.rand.nextInt(6) == 0)
+            FMLClientHandler.instance().getClient().effectRenderer.addEffect(steam);
     }
 
     public int getColor(PotionEssence essence) {
@@ -92,6 +94,7 @@ public class TileEntityCauldron extends TileEntityBase {
         return  PotionHelper.calcPotionLiquidColor(essence.getEffects());
     }
 
+    @SideOnly(Side.CLIENT)
     public void spawnGunpowderParticles() {
         if (worldObj.rand.nextInt(8) > 0)
             return;
@@ -100,6 +103,7 @@ public class TileEntityCauldron extends TileEntityBase {
         worldObj.spawnParticle("smoke", xCoord + 0.5D + xOffset, yCoord + BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), zCoord + 0.5D + zOffset, 0.0D, 0.1D, 0.0D);
     }
 
+    @SideOnly(Side.CLIENT)
     public void spawnGlowstoneParticles() {
         if (worldObj.rand.nextInt(8) > 0)
             return;
@@ -109,6 +113,7 @@ public class TileEntityCauldron extends TileEntityBase {
         worldObj.spawnParticle("mobSpell", xCoord + 0.5D + xOffset, yCoord + BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), zCoord + 0.5D + zOffset, gauss, gauss, 0.0F);
     }
 
+    @SideOnly(Side.CLIENT)
     public void spawnNetherwartParticles() {
         if (worldObj.rand.nextInt(8) > 0)
             return;
@@ -118,6 +123,7 @@ public class TileEntityCauldron extends TileEntityBase {
         worldObj.spawnParticle("mobSpell", xCoord + 0.5D + xOffset, yCoord + BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), zCoord + 0.5D + zOffset, gauss, 0.0F, gauss);
     }
 
+    @SideOnly(Side.CLIENT)
     public void spawnRedstoneParticles() {
         if (worldObj.rand.nextInt(10) / this.redstoneCount > 0)
             return;
@@ -126,6 +132,7 @@ public class TileEntityCauldron extends TileEntityBase {
         worldObj.spawnParticle("reddust", xCoord + 0.5D + xOffset, yCoord + BlockCauldron.getRenderLiquidLevel(worldObj.getBlockMetadata(xCoord, yCoord, zCoord)), zCoord + 0.5D + zOffset, 1D, 0D, 0D);
     }
 
+    @SideOnly(Side.CLIENT)
     public void spawnFinishedParticles() {
         if (worldObj.rand.nextInt(8) > 0)
             return;

--- a/src/main/java/xreliquary/client/particle/EntityCauldronBubbleFX.java
+++ b/src/main/java/xreliquary/client/particle/EntityCauldronBubbleFX.java
@@ -1,18 +1,25 @@
 package xreliquary.client.particle;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+
 import org.lwjgl.opengl.GL11;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import xreliquary.lib.Names;
 import xreliquary.lib.Reference;
 
 /**
  * Created by Xeno on 11/9/2014.
  */
+@SideOnly(Side.CLIENT)
 public class EntityCauldronBubbleFX extends EntityFX {
     private static ResourceLocation bubbleTexture = new ResourceLocation(Reference.MOD_ID + ":textures/particles/" + Names.cauldron_bubble + ".png");
 

--- a/src/main/java/xreliquary/entities/shot/EntityShotBase.java
+++ b/src/main/java/xreliquary/entities/shot/EntityShotBase.java
@@ -443,7 +443,9 @@ public abstract class EntityShotBase extends Entity implements IProjectile {
             this.motionX = seekVector.xCoord * 0.4D;
             this.motionY = seekVector.yCoord * 0.4D;
             this.motionZ = seekVector.zCoord * 0.4D;
-            this.setVelocity(motionX, motionY, motionZ);
+            if(worldObj.isRemote){
+                this.setVelocity(motionX, motionY, motionZ);
+            }
         }
     }
 

--- a/src/main/java/xreliquary/items/ItemMagazine.java
+++ b/src/main/java/xreliquary/items/ItemMagazine.java
@@ -90,7 +90,7 @@ public class ItemMagazine extends ItemBase {
     @Override
     public void addInformation(ItemStack stack, EntityPlayer par2EntityPlayer, List list, boolean par4) {
         if (stack.getItemDamage() < 2) {
-            list.add(LanguageHelper.getLocalization("item." + Names.magazine + "_" + stack.getItemDamage() + ".tooltip"));
+            //list.add(LanguageHelper.getLocalization("item." + Names.magazine + "_" + stack.getItemDamage() + ".tooltip"));
         } else {
             list.add(LanguageHelper.getLocalization("item." + Names.bullet + "_" + stack.getItemDamage() + ".tooltip"));
         }


### PR DESCRIPTION
Prevents server crashes from a part of the bullet homing effect (fixing #201 and possibly #197), as well
as cauldron particle effect crashes.
The cauldron now only takes what it can use from item stacks thrown into it (also meaning that if multiple redstone are thrown in, it recognizes more than the addition of just one).
I also commented-out the line adding unused tooltips for the empty and standard magazines.